### PR TITLE
Allow backup name to be changed in settings

### DIFF
--- a/blobbackup/models.py
+++ b/blobbackup/models.py
@@ -281,3 +281,12 @@ class Backups(object):
         del plans[name]
         with open(MODEL_PATH, "wb") as f:
             f.write(set_object(plans))
+
+    @staticmethod
+    def change_name(old_name, new_name):
+        plans = Backups.load_all()
+        plans[new_name] = plans[old_name]
+        plans[new_name].name = new_name
+        del plans[old_name]
+        with open(MODEL_PATH, "wb") as f:
+            f.write(set_object(plans))

--- a/blobbackup/ui/backup_settings.ui
+++ b/blobbackup/ui/backup_settings.ui
@@ -459,6 +459,26 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_6">
        <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_8">
+         <item>
+          <widget class="QLabel" name="label_6">
+           <property name="minimumSize">
+            <size>
+             <width>140</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Backup name:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="backup_name_line_edit"/>
+         </item>
+        </layout>
+       </item>
+       <item>
         <layout class="QHBoxLayout" name="horizontalLayout_7">
          <item>
           <widget class="QLabel" name="label_5">

--- a/blobbackup/ui_backup_settings.py
+++ b/blobbackup/ui_backup_settings.py
@@ -289,6 +289,22 @@ class Ui_BackupSettingsDialog(object):
         self.tabWidgetPage5.setObjectName(u"tabWidgetPage5")
         self.verticalLayout_6 = QVBoxLayout(self.tabWidgetPage5)
         self.verticalLayout_6.setObjectName(u"verticalLayout_6")
+        self.horizontalLayout_8 = QHBoxLayout()
+        self.horizontalLayout_8.setObjectName(u"horizontalLayout_8")
+        self.label_6 = QLabel(self.tabWidgetPage5)
+        self.label_6.setObjectName(u"label_6")
+        self.label_6.setMinimumSize(QSize(140, 0))
+
+        self.horizontalLayout_8.addWidget(self.label_6)
+
+        self.backup_name_line_edit = QLineEdit(self.tabWidgetPage5)
+        self.backup_name_line_edit.setObjectName(u"backup_name_line_edit")
+
+        self.horizontalLayout_8.addWidget(self.backup_name_line_edit)
+
+
+        self.verticalLayout_6.addLayout(self.horizontalLayout_8)
+
         self.horizontalLayout_7 = QHBoxLayout()
         self.horizontalLayout_7.setObjectName(u"horizontalLayout_7")
         self.label_5 = QLabel(self.tabWidgetPage5)
@@ -398,6 +414,7 @@ class Ui_BackupSettingsDialog(object):
 #endif // QT_CONFIG(tooltip)
         self.keep_last_radio_button.setText(QCoreApplication.translate("BackupSettingsDialog", u"Keep last (days): ", None))
         self.tabWidget.setTabText(self.tabWidget.indexOf(self.tabWidgetPage4), QCoreApplication.translate("BackupSettingsDialog", u"Retention", None))
+        self.label_6.setText(QCoreApplication.translate("BackupSettingsDialog", u"Backup name:", None))
         self.label_5.setText(QCoreApplication.translate("BackupSettingsDialog", u"Thread count: ", None))
         self.label_9.setText(QCoreApplication.translate("BackupSettingsDialog", u"Threads", None))
         self.label_7.setText(QCoreApplication.translate("BackupSettingsDialog", u"Compression level:", None))


### PR DESCRIPTION
Backup name can now be changed under Settings > Advanced.

Resolves https://github.com/BlobBackup/BlobBackup/issues/49