### PR TITLE
Add name in backup settings title

### DIFF
--- a/blobbackup/backup_settings.py
+++ b/blobbackup/backup_settings.py
@@ -34,7 +34,7 @@ class BackupSettings(QDialog, Ui_BackupSettingsDialog):
         self.days_checked = set()
 
         prefix = self.backup.cloud_prefix if self.backup.cloud_prefix is not None else self.backup.local_directory
-        window_title = f"{self.backup.location} ({prefix})"
+        window_title = f"{self.backup.location}: {self.backup.name} ({prefix})"
 
         # Hiding unsupported add file button for now
         self.add_file_button.hide()


### PR DESCRIPTION
As discussed in #70, I think that the name of the backup should be in the title of the backup settings window.
Don't hesitate to close this PR if it is unwanted, I have done it out of the blue :)