### PR TITLE
Fix last file left open bug

### DIFF
--- a/blobbackup/repo2.py
+++ b/blobbackup/repo2.py
@@ -80,13 +80,12 @@ class ConcatBytesIO(object):
             if len(read_bytes) is 0:
                 if self.file is not None:
                     self.file_finished_callback(self.path, self.consumed)
+                    self.file.close()
                 try:
                     self.path = next(self.paths)
                 except StopIteration:
                     self.done = True
                     break
-                if self.file is not None:
-                    self.file.close()
                 if can_read(self.path):
                     self.file = open(self.path, "rb")
                 else:


### PR DESCRIPTION
Related to https://github.com/BlobBackup/BlobBackup/issues/64

There was a bug in the backup logic that left the last file open after a backup was done running. I guess this only surfaces to the user on windows...

Anyway, I think this fixes it.