### PR TITLE
Adding new tests to prepare the code to refactor the routes into controllers

### DIFF
--- a/server/app/Services/B2Client.php
+++ b/server/app/Services/B2Client.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Services;
+
+
+use Illuminate\Support\Facades\Http;
+
+class B2Client
+{
+    public function __construct()
+    {
+        // todo: implement constructor
+    }
+
+    public function authorizeAccount()
+    {
+        return Http::withBasicAuth(env('B2_KEY_ID'), env('B2_APPLICATION_KEY'))
+            ->get('https://api.backblazeb2.com/b2api/v2/b2_authorize_account');
+    }
+
+    public function createKey($token, $api_url, $name)
+    {
+        $data = [
+            'keyName' => $name,
+            'namePrefix' => $name,
+            'bucketId' => env('B2_BUCKET_ID'),
+            'accountId' => env('B2_ACCOUNT_ID'),
+            'capabilities' => [
+                'listFiles',
+                'readFiles',
+                'writeFiles',
+                'deleteFiles',
+                'listBuckets',
+            ],
+        ];
+
+        return Http::withHeaders(['Authorization' => $token])
+            ->post($api_url . '/b2api/v2/b2_create_key', $data);
+    }
+}

--- a/server/database/factories/ComputerFactory.php
+++ b/server/database/factories/ComputerFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use App\Util\Util;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ComputerFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->name(),
+            'uuid' => $this->faker->uuid(),
+            'operating_system' => $this->faker->word(),
+            'b2_key_id' => $this->faker->word(),
+            'b2_application_key' => $this->faker->word(),
+            'last_backed_up_at' => now(),
+            'last_backed_up_num_files' => $this->faker->randomNumber(5),
+            'last_backed_up_size' => $this->faker->randomNumber(9),
+            'created_at' => now(),
+            'updated_at' => now(),
+            'client_version' => Util::$clientVersion,
+            'user_id' => User::factory(),
+        ];
+    }
+
+    public function existingUser(User $user)
+    {
+        return $this->state(function (array $attributes) use ($user) {
+            return [
+                'user_id' => $user->id,
+            ];
+        });
+    }
+}

--- a/server/database/factories/UserFactory.php
+++ b/server/database/factories/UserFactory.php
@@ -2,11 +2,26 @@
 
 namespace Database\Factories;
 
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 
 class UserFactory extends Factory
 {
+    /**
+     * Configure the model factory.
+     *
+     * @return $this
+     */
+    public function configure()
+    {
+        return $this->afterCreating(function (User $user) {
+            $user->createAsCustomer([
+                'trial_ends_at' => now()->addDays(30),
+            ]);
+        });
+    }
+
     /**
      * Define the model's default state.
      *
@@ -25,13 +40,29 @@ class UserFactory extends Factory
     /**
      * Indicate that the model's email address should be unverified.
      *
-     * @return \Illuminate\Database\Eloquent\Factories\Factory
+     * @return Factory
      */
     public function unverified()
     {
         return $this->state(function (array $attributes) {
             return [
                 'email_verified_at' => null,
+            ];
+        });
+    }
+
+    /**
+     * Indicate that the model's email and password should be fixed for testing consistency
+     * because the front-end uses encryption
+     *
+     * @return Factory
+     */
+    public function forTesting(?string $email = null, ?string $encrypted_password = null)
+    {
+        return $this->state(function () use ($email, $encrypted_password) {
+            return [
+                'email' => $email ?? 'test@email.com',
+                'password' => $encrypted_password ?? bcrypt('b6yOfA0cIthbuYerlb/KodNcJlp1aO4uW8hOpXydBdk='),
             ];
         });
     }

--- a/server/phpunit.xml
+++ b/server/phpunit.xml
@@ -28,5 +28,10 @@
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="TELESCOPE_ENABLED" value="false"/>
+        <env name="B2_ACCOUNT_ID" value="fake-b2-acc-id"/>
+        <env name="B2_BUCKET_NAME" value="fake-b2-bucket-name"/>
+        <env name="B2_BUCKET_ID" value="fake-b2-bucket-id"/>
+        <env name="B2_KEY_ID" value="fake-b2-key-id"/>
+        <env name="B2_APPLICATION_KEY" value="fake-b2-app-key"/>
     </php>
 </phpunit>

--- a/server/tests/Feature/Api/AuthenticationTest.php
+++ b/server/tests/Feature/Api/AuthenticationTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\TestCase;
+
+class AuthenticationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public $user;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->forTesting()->create();
+    }
+
+    public function test_user_can_authenticate_with_basic_auth()
+    {
+        $base64_credentials = base64_encode('test@email.com:b6yOfA0cIthbuYerlb/KodNcJlp1aO4uW8hOpXydBdk=');
+
+        $headers = [
+            'Authorization' => 'Basic ' . $base64_credentials,
+            'Accept' => 'application/json',
+        ];
+
+        $response = $this->withHeaders($headers)
+            ->get('/api/login');
+
+        $response->assertStatus(Response::HTTP_OK);
+
+        $response->assertJson([
+            'on_trial' => true,
+            'subscribed' => false,
+        ]);
+    }
+
+    public function test_user_can_not_authenticate_with_invalid_password()
+    {
+        $base64_credentials = base64_encode('test@email.com:invalid_password');
+
+        $headers = [
+            'Authorization' => 'Basic ' . $base64_credentials,
+            'Accept' => 'application/json',
+        ];
+
+        $response = $this->withHeaders($headers)
+            ->get('/api/login');
+
+        $response->assertStatus(Response::HTTP_UNAUTHORIZED);
+    }
+
+    public function test_it_returns_unauthorized_when_missing_basic_auth_headers()
+    {
+        $headers = [
+            'Accept' => 'application/json',
+        ];
+
+        $response = $this->withHeaders($headers)
+            ->get('/api/login');
+
+        $response->assertStatus(Response::HTTP_UNAUTHORIZED);
+    }
+}

--- a/server/tests/Feature/Api/ClientTest.php
+++ b/server/tests/Feature/Api/ClientTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Util\Util;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ClientTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_returns_client_version_correctly()
+    {
+        $expected_version = Util::$clientVersion;
+
+        $response = $this->get('/api/client/version');
+        
+        $response->assertStatus(200)
+            ->assertSee($expected_version);
+    }
+}

--- a/server/tests/Feature/Api/ComputersTest.php
+++ b/server/tests/Feature/Api/ComputersTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Computer;
+use App\Models\User;
+use App\Util\Util;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\TestCase;
+
+class ComputersTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public $user1;
+    public $user2;
+    public $computer1;
+    public $computer2;
+    public $computer3;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user1 = User::factory()->forTesting()->create();
+        $this->user2 = User::factory()->forTesting('test2@email.com')->create();
+
+        $this->computer1 = Computer::factory()->existingUser($this->user1)->create();
+        $this->computer2 = Computer::factory()->existingUser($this->user1)->create();
+        $this->computer3 = Computer::factory()->existingUser($this->user2)->create();
+    }
+
+    public function test_it_can_list_all_computers_for_authenticated_user()
+    {
+        $base64_credentials = base64_encode('test@email.com:b6yOfA0cIthbuYerlb/KodNcJlp1aO4uW8hOpXydBdk=');
+
+        $headers = [
+            'Authorization' => 'Basic ' . $base64_credentials,
+            'Accept' => 'application/json',
+        ];
+
+        $response = $this->withHeaders($headers)
+            ->get('/api/computers');
+
+        $expected_response = [
+            [
+                'id' => 1,
+                'user_id' => 1,
+                'name' => $this->computer1->name,
+            ],
+            [
+                'id' => 2,
+                'user_id' => 1,
+                'name' => $this->computer2->name,
+            ],
+        ];
+
+        $response->assertOk()
+            ->assertJsonCount(2)
+            ->assertJson($expected_response);
+    }
+
+    public function test_it_can_not_access_computers_without_authentication()
+    {
+        $headers = [
+            'Accept' => 'application/json',
+        ];
+
+        $response = $this->withHeaders($headers)
+            ->get('/api/computers');
+
+        $response->assertStatus(Response::HTTP_UNAUTHORIZED);
+    }
+
+    public function test_it_can_get_a_computer()
+    {
+        $base64_credentials = base64_encode('test@email.com:b6yOfA0cIthbuYerlb/KodNcJlp1aO4uW8hOpXydBdk=');
+
+        $headers = [
+            'Authorization' => 'Basic ' . $base64_credentials,
+            'Accept' => 'application/json',
+        ];
+
+        $response = $this->withHeaders($headers)
+            ->get('/api/computers/2');
+
+        $expected_response = [
+            'id' => 2,
+            'user_id' => 1,
+            'name' => $this->computer2->name,
+            'uuid' => $this->computer2->uuid,
+            'operating_system' => $this->computer2->operating_system,
+            'b2_key_id' => $this->computer2->b2_key_id,
+            'b2_application_key' => $this->computer2->b2_application_key,
+            'last_backed_up_num_files' => $this->computer2->last_backed_up_num_files,
+            'last_backed_up_size' => $this->computer2->last_backed_up_size,
+            'deleted_at' => null,
+            'client_version' => Util::$clientVersion,
+            'b2_bucket_name' => env('B2_BUCKET_NAME'),
+        ];
+
+        $response->assertOk()
+            ->assertJson($expected_response);
+    }
+
+    public function test_it_can_not_access_a_computer_without_authentication()
+    {
+        $headers = [
+            'Accept' => 'application/json',
+        ];
+
+        $response = $this->withHeaders($headers)
+            ->get('/api/computers/1');
+
+        $response->assertStatus(Response::HTTP_UNAUTHORIZED);
+    }
+}

--- a/server/tests/Feature/Api/ComputersTest.php
+++ b/server/tests/Feature/Api/ComputersTest.php
@@ -187,4 +187,57 @@ class ComputersTest extends TestCase
 
         $response->assertStatus(Response::HTTP_UNAUTHORIZED);
     }
+
+    public function test_it_can_update_a_computer_correctly()
+    {
+        $base64_credentials = base64_encode('test@email.com:b6yOfA0cIthbuYerlb/KodNcJlp1aO4uW8hOpXydBdk=');
+
+        $headers = [
+            'Authorization' => 'Basic ' . $base64_credentials,
+            'Accept' => 'application/json',
+        ];
+
+        $data = [
+            'name' => 'computer-name',
+            'operating_system' => 'FAKE_TEST_OS',
+            'last_backed_up_at' => '1649199766',
+            'last_backed_up_num_files' => '17',
+            'last_backed_up_size' => '84033019',
+            'client_version' => Util::$clientVersion,
+        ];
+
+        $response = $this->withHeaders($headers)
+            ->post('api/computers/1', $data);
+
+        $expected_result = [
+            'id' => 1,
+            'name' => 'computer-name',
+            'operating_system' => 'FAKE_TEST_OS',
+            'last_backed_up_at' => '2022-04-05 23:02:46',
+            'last_backed_up_num_files' => '17',
+            'last_backed_up_size' => '84033019',
+            'client_version' => Util::$clientVersion,
+        ];
+
+        $response->assertStatus(Response::HTTP_OK)
+            ->assertJsonStructure(array_keys($expected_result));
+
+        $this->assertDatabaseHas('computers', $expected_result);
+    }
+
+    public function test_it_can_not_update_a_computer_without_authentication()
+    {
+        $headers = [
+            'Accept' => 'application/json',
+        ];
+
+        $data = [
+            'client_version' => Util::$clientVersion,
+        ];
+
+        $response = $this->withHeaders($headers)
+            ->post('api/computers/1', $data);
+
+        $response->assertStatus(Response::HTTP_UNAUTHORIZED);
+    }
 }


### PR DESCRIPTION
Hello! This PR adds missing tests for api routes.

These are the tests I'm working on to prepare API code for secure refactoring and migrate code from routes to dedicated controllers and improvements in separation of concerns.

Progress:
- [x] Test GET /api/client/version
- [x] Test GET /api/login
- [x] Test GET /api/computers
- [x] Test POST /api/computers
- [x] Test GET /api/computers/{computer}
- [x] Test POST /api/computers/{computer}

